### PR TITLE
idea of board state and rendering game elements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,9 @@
-import styles from './App.css';
 import { useState } from 'react';
-import {
-  RecoilRoot,
-  atom,
-  selector,
-  useRecoilState,
-  useRecoilValue,
-} from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import { counterState } from './recoil/atoms/count';
+import { boardState } from './recoil/atoms/board';
 
-import Droppable from './components/Droppable';
-import Draggable from './components/Draggable';
 import { DndContext } from '@dnd-kit/core';
 import { createSnapModifier } from '@dnd-kit/modifiers';
 import Board from './components/Board';
@@ -20,8 +12,12 @@ import Place from './components/Place';
 import Drawer from './components/Drawer';
 import { drawerVisibilityState } from './recoil/atoms/ui';
 
+import { PlaceProperties, CardProperties } from './type';
+import RenderGameElement from './helper';
+
 function App() {
   const [counter, setCounter] = useRecoilState(counterState);
+  const [board, setBoard] = useRecoilState(boardState);
   const [isDropped, setIsDropped] = useState(false);
   const [isDrawerVisible, setIsDrawerVisible] = useRecoilState(
     drawerVisibilityState
@@ -33,7 +29,36 @@ function App() {
     }
   };
 
+  // test function for adding items to state and displaying
+  const setNewItem = () => {
+    setBoard([
+      ...board,
+      // creating test place
+      // TODO: might want a generator function for these
+      {
+        id: `testPlace${counter}`,
+        coordinates: { x: counter * 100, y: counter * 100 },
+        size: { width: 100, height: 100 },
+        title: `test place ${counter}`,
+        // and children cards
+        childElements: [
+          {
+            id: `testCard${counter}`,
+            coordinates: { x: counter * 100, y: counter * 100 },
+            size: { width: 100, height: 100 },
+            title: `test card ${counter}`,
+            state: 'head',
+            Component: Card,
+          } as CardProperties,
+        ],
+        Component: Place,
+      } as PlaceProperties,
+    ]);
+    setCounter(counter + 1);
+  };
+
   const gridSize = 20; // pixels
+  // TODO: this needs to be applied to all droppable elements
   const snapToGridModifier = createSnapModifier(gridSize);
 
   const handleOnClick = () => {
@@ -43,15 +68,12 @@ function App() {
   return (
     <div className="App">
       <Drawer />
+      <button onClick={setNewItem}>add new item</button>
       <DndContext onDragEnd={handleDragEnd} modifiers={[snapToGridModifier]}>
         <Board>
-          <Card
-            id="draggable"
-            url="https://picsum.photos/50/40"
-            title={'test card'}
-            description={'this is description of description'}
-          />
-          <Place id={'place'} title={'test place'} />
+          {board.map((gameElement) => {
+            return <RenderGameElement gameElement={gameElement} />;
+          })}
         </Board>
       </DndContext>
       <div style={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/src/components/Place/PlaceVisual.tsx
+++ b/src/components/Place/PlaceVisual.tsx
@@ -1,31 +1,33 @@
 import React, { CSSProperties } from 'react';
+import { PlaceProperties } from '../../type';
+import RenderGameElement from '../../helper';
 
 const CARD_WIDTH = 59;
 const CARD_HEIGHT = 91;
 const RATIO = 1.5;
 const PADDING = 10;
 
-type Props = React.PropsWithChildren & {
-  title?: string;
-  attachedCards?: React.ReactNode;
-};
+function PlaceVisual(props: PlaceProperties & React.PropsWithChildren) {
+  const {
+    title,
+    coordinates: { x, y },
+  } = props;
+  const topChildren = props.childElements?.[0];
 
-function PlaceVisual(props: Props) {
-  const { title, attachedCards } = props;
+  const style: CSSProperties = {
+    width: `${CARD_WIDTH * RATIO + 2 * PADDING}px`,
+    height: `${CARD_HEIGHT * RATIO + 2 * PADDING}px`,
+    border: '1px solid',
+    borderRadius: '10px',
+    transform: `translate3d(${x}px, ${y}px, 0)`,
+  };
 
   return (
     <div style={style}>
       <div>{title}</div>
-      <div>{props.children}</div>
+      {topChildren && <RenderGameElement gameElement={topChildren} />}
     </div>
   );
 }
-
-const style: CSSProperties = {
-  width: `${CARD_WIDTH * RATIO + 2 * PADDING}px`,
-  height: `${CARD_HEIGHT * RATIO + 2 * PADDING}px`,
-  border: '1px solid',
-  borderRadius: '10px',
-};
 
 export default PlaceVisual;

--- a/src/components/Place/index.tsx
+++ b/src/components/Place/index.tsx
@@ -3,24 +3,18 @@ import Draggable from '../Draggable';
 import Droppable from '../Droppable';
 import PlaceVisual from './PlaceVisual';
 
-type Props = React.PropsWithChildren & {
-  id: string;
-  title?: string;
-  attachedCards?: React.ReactNode;
-};
+import { PlaceProperties } from '../../type';
 
-function Place(props: Props) {
-  const { id, ...rest } = props;
-
+function Place(props: PlaceProperties) {
   const handleDragEnd = (event: any) => {
     // TODO: impl
   };
 
   return (
-    <Draggable id={id}>
+    <Draggable id={props.id}>
       <DndContext onDragEnd={handleDragEnd}>
-        <PlaceVisual {...rest}>
-          <Droppable id={`place${id}`} />
+        <PlaceVisual {...props}>
+          <Droppable id={`place${props.id}`} />
         </PlaceVisual>
       </DndContext>
     </Draggable>

--- a/src/helper.tsx
+++ b/src/helper.tsx
@@ -1,0 +1,7 @@
+import { GameElement } from './type';
+
+function RenderGameElement(props: { gameElement: GameElement }) {
+  const { Component, ...rest } = props.gameElement;
+  return <Component {...rest} />;
+}
+export default RenderGameElement;

--- a/src/recoil/atoms/board.ts
+++ b/src/recoil/atoms/board.ts
@@ -1,0 +1,7 @@
+import { atom } from 'recoil';
+import { GameElement } from '../../type';
+
+export const boardState = atom<GameElement[]>({
+  key: 'boardState',
+  default: [],
+});

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,7 +1,9 @@
+import { ReactNode } from 'react';
+
 type BaseProperties = {
   id: string;
-  isDroppable: boolean;
-  isDraggable: boolean;
+  isDroppable?: boolean;
+  isDraggable?: boolean;
   coordinates: {
     x: number;
     y: number;
@@ -11,30 +13,46 @@ type BaseProperties = {
     height: number;
   };
   parent?: GameElement;
-  children?: GameElement[];
+  childElements?: GameElement[];
+  Component: React.FC<Omit<BaseProperties, 'Component'>>;
 };
 
-type GameElement = Card | DummyCard | Deck | Place | Board;
+type GameElement =
+  | CardProperties
+  | DummyCardProperties
+  | DeckProperties
+  | PlaceProperties
+  | BoardProperties;
 
 type CardState = 'head' | 'tail' | 'sideHead' | 'sideTail';
 
-type Card = BaseProperties & {
+// TODO: sync the types below with the props of each component
+
+type CardProperties = BaseProperties & {
   title: string;
   image?: string;
   description?: string;
   state: CardState;
 };
 
-type DummyCard = Omit<Card, 'description'>;
+type DummyCardProperties = Omit<CardProperties, 'description'>;
 
-type Deck = BaseProperties & {
+type DeckProperties = BaseProperties & {
   image?: string;
 };
 
-type Place = BaseProperties & {
+type PlaceProperties = BaseProperties & {
+  title?: string;
   color?: string;
 };
 
-type Board = BaseProperties & {};
+type BoardProperties = BaseProperties & {};
 
-export type { Card, Deck, DummyCard, Place, Board };
+export type {
+  CardProperties,
+  DeckProperties,
+  DummyCardProperties,
+  PlaceProperties,
+  BoardProperties,
+  GameElement,
+};


### PR DESCRIPTION
## 変更点

- stateにgame elementをつっこんで描画するの実装してみました(仮)
  - BasePropertiesにComponentを追加
  - 一応Placeの下にCardがおけるのとかそれぞれ別にドラッグできるの試してみてください
- 描画の実装の都合上typeで作ったgame elementを各コンポーネントのpropsに変更
  - ついでにPlaceをx, yで位置調整できるか確認

## 懸念点

- 設計あんまよくなさそう？
  - game element追加する時に各タイプのファクトリーorそれっぽいのが必要
  - stateをGameElement[]の代わりにReactNode[]にしても解決しなさそう
- onDragEnd()でstateをいじってchildElements木を操作する予定だけど，再レンダリングとかで重くならないか 