### PR TITLE
Remove dndcontext from droppable, render droppable in place

### DIFF
--- a/src/components/Place/index.tsx
+++ b/src/components/Place/index.tsx
@@ -1,4 +1,3 @@
-import { DndContext } from '@dnd-kit/core';
 import Draggable from '../Draggable';
 import Droppable from '../Droppable';
 import PlaceVisual from './PlaceVisual';
@@ -6,17 +5,11 @@ import PlaceVisual from './PlaceVisual';
 import { PlaceProperties } from '../../type';
 
 function Place(props: PlaceProperties) {
-  const handleDragEnd = (event: any) => {
-    // TODO: impl
-  };
-
   return (
     <Draggable id={props.id}>
-      <DndContext onDragEnd={handleDragEnd}>
-        <PlaceVisual {...props}>
-          <Droppable id={`place${props.id}`} />
-        </PlaceVisual>
-      </DndContext>
+      <Droppable id={`place${props.id}`}>
+        <PlaceVisual {...props} />
+      </Droppable>
     </Draggable>
   );
 }


### PR DESCRIPTION
## 概要

- `<Droppable/>`からDndContextを削除
- Place内のDroppableがレンダーされるように構造変更