### PR TITLE
Add discriminated union type for game elements

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,9 @@ import { boardState } from './recoil/atoms/board';
 import { DndContext } from '@dnd-kit/core';
 import { createSnapModifier } from '@dnd-kit/modifiers';
 import Board from './components/Board';
-import Card from './components/Card';
-import Place from './components/Place';
 import Drawer from './components/Drawer';
 import { drawerVisibilityState } from './recoil/atoms/ui';
 
-import { PlaceProperties, CardProperties } from './type';
 import RenderGameElement from './components/RenderGameElement';
 import { BOARD_ID } from './constants';
 import useHandleDragEnd from './hooks/useHandleDragEnd';
@@ -30,6 +27,7 @@ function App() {
     newBoard.childElements = [
       ...(board?.childElements ?? []),
       {
+        type: 'PLACE',
         id: `testPlace${counter}`,
         coordinates: { x: counter * 100, y: counter * 100 },
         size: { width: 100, height: 100 },
@@ -38,17 +36,17 @@ function App() {
         // and children cards
         childElements: [
           {
+            type: 'CARD',
             id: `testCard${counter}`,
             coordinates: { x: counter * 100, y: counter * 100 },
             size: { width: 100, height: 100 },
             title: `test card ${counter}`,
+            imageUrl: 'https://picsum.photos/60/90',
             state: 'head',
             parentId: `testPlace${counter}`,
-            Component: Card,
-          } as CardProperties,
+          },
         ],
-        Component: Place,
-      } as PlaceProperties,
+      },
     ];
 
     setBoard(newBoard);

--- a/src/components/Card/CardVisual.tsx
+++ b/src/components/Card/CardVisual.tsx
@@ -1,21 +1,18 @@
-import React, { CSSProperties } from 'react';
+import { CSSProperties } from 'react';
+import { CardProperties } from '../../type';
 
 const CARD_WIDTH = 59;
 const CARD_HEIGHT = 91;
 const RATIO = 1.5;
 
-type Props = React.PropsWithChildren & {
-  url?: string;
-  title?: string;
-  description?: string;
-};
+export type Props = Omit<CardProperties, 'type'>;
 
 function CardVisual(props: Props) {
-  const { url, title, description } = props;
+  const { imageUrl, title, description } = props;
   return (
     <div style={style}>
       <div>{title}</div>
-      <img src={url} />
+      <img src={imageUrl} />
       <div>{description}</div>
     </div>
   );

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,12 +1,9 @@
+import { CardProperties } from '../../type';
 import Draggable from '../Draggable';
 import CardVisual from './CardVisual';
+import { Props as CardVisualProps } from './CardVisual';
 
-type Props = React.PropsWithChildren & {
-  id: string;
-  url?: string;
-  title?: string;
-  description?: string;
-};
+type Props = CardVisualProps;
 
 function Card(props: Props) {
   const handleDragEnd = (event: any) => {

--- a/src/components/Place/PlaceVisual.tsx
+++ b/src/components/Place/PlaceVisual.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import { CSSProperties } from 'react';
 import { PlaceProperties } from '../../type';
 import RenderGameElement from '../RenderGameElement';
 
@@ -7,7 +7,9 @@ const CARD_HEIGHT = 91;
 const RATIO = 1.5;
 const PADDING = 10;
 
-function PlaceVisual(props: PlaceProperties & React.PropsWithChildren) {
+export type Props = Omit<PlaceProperties, 'type'>;
+
+function PlaceVisual(props: Props) {
   const {
     title,
     coordinates: { x, y },

--- a/src/components/Place/index.tsx
+++ b/src/components/Place/index.tsx
@@ -2,9 +2,11 @@ import Draggable from '../Draggable';
 import Droppable from '../Droppable';
 import PlaceVisual from './PlaceVisual';
 
-import { PlaceProperties } from '../../type';
+import {Props as PlaceVisualProps} from './PlaceVisual';
 
-function Place(props: PlaceProperties) {
+type Props = PlaceVisualProps;
+
+function Place(props: Props) {
   return (
     <Draggable id={props.id}>
       <Droppable id={`place${props.id}`}>

--- a/src/components/RenderGameElement.tsx
+++ b/src/components/RenderGameElement.tsx
@@ -1,7 +1,21 @@
 import { GameElement } from '../type';
+import Board from './Board';
+import Card from './Card';
+import Place from './Place';
 
 function RenderGameElement(props: { gameElement: GameElement }) {
-  const { Component, ...rest } = props.gameElement;
-  return <Component {...rest} />;
+  const { gameElement } = props;
+  switch (gameElement.type) {
+    case 'BOARD':
+      return <Board {...gameElement} />;
+    case 'PLACE':
+      return <Place {...gameElement} />;
+    case 'CARD':
+      return <Card {...gameElement} />;
+    case 'DECK':
+      return <div>TBD</div>;
+    case 'DUMMY_CARD':
+      return <div>TBD</div>;
+  }
 }
 export default RenderGameElement;

--- a/src/components/RenderGameElement.tsx
+++ b/src/components/RenderGameElement.tsx
@@ -16,6 +16,10 @@ function RenderGameElement(props: { gameElement: GameElement }) {
       return <div>TBD</div>;
     case 'DUMMY_CARD':
       return <div>TBD</div>;
+    default:
+      const { type } = gameElement;
+      const exhaustivenessCheck: never = type;
+      return exhaustivenessCheck;
   }
 }
 export default RenderGameElement;

--- a/src/recoil/atoms/board.ts
+++ b/src/recoil/atoms/board.ts
@@ -1,11 +1,11 @@
 import { atom } from 'recoil';
-import Board from '../../components/Board';
 import { BOARD_ID } from '../../constants';
 import { BoardProperties, GameElement } from '../../type';
 
 export const boardState = atom<GameElement>({
   key: 'boardState',
   default: {
+    type: 'BOARD',
     id: BOARD_ID,
     childElements: [],
     coordinates: {
@@ -16,7 +16,6 @@ export const boardState = atom<GameElement>({
       width: 800,
       height: 500,
     },
-    Component: Board,
     parentId: 'null',
   } as BoardProperties,
 });

--- a/src/type.ts
+++ b/src/type.ts
@@ -12,7 +12,6 @@ type BaseProperties = {
   };
   parentId?: string;
   childElements?: GameElement[];
-  Component: React.FC<Omit<BaseProperties, 'Component'>>;
 };
 
 type GameElement =
@@ -27,24 +26,34 @@ type CardState = 'head' | 'tail' | 'sideHead' | 'sideTail';
 // TODO: sync the types below with the props of each component
 
 type CardProperties = BaseProperties & {
+  type: 'CARD';
   title: string;
-  image?: string;
-  description?: string;
   state: CardState;
+  imageUrl?: string;
+  description?: string;
 };
 
-type DummyCardProperties = Omit<CardProperties, 'description'>;
+type DummyCardProperties = BaseProperties & {
+  type: 'DUMMY_CARD'
+  title: string;
+  state: CardState;
+  imageUrl?: string;
+};
 
 type DeckProperties = BaseProperties & {
+  type: 'DECK'
   image?: string;
 };
 
 type PlaceProperties = BaseProperties & {
+  type: 'PLACE'
   title?: string;
   color?: string;
 };
 
-type BoardProperties = BaseProperties;
+type BoardProperties = BaseProperties & {
+  type: 'BOARD'
+};
 
 export type {
   CardProperties,


### PR DESCRIPTION
なんか色々問題が起きそうなので、game elementにcomponent自体を持たせるのをやめて判別可能なユニオン型を持たせて絞り込む方式にしました

ref: https://typescriptbook.jp/reference/values-types-variables/discriminated-union